### PR TITLE
Add Next.js landing page skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# CasaVidaSite
+# CasaVidaOS Landing Page
+
+This repository contains a simple [Next.js](https://nextjs.org/) site for the Casa-VidaOS landing page. It is configured so the static output can be hosted on GitHub Pages for testing or demonstration.
+
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Static Export
+
+To build the site and generate a static export (useful for GitHub Pages):
+
+```bash
+npm run deploy
+```
+
+The exported files will be placed in the `out` folder.
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+const isGithubPages = process.env.GITHUB_PAGES === 'true';
+const repoName = 'CasaVidaSite';
+
+module.exports = {
+  trailingSlash: true,
+  assetPrefix: isGithubPages ? `/${repoName}/` : '',
+  basePath: isGithubPages ? `/${repoName}` : '',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "casa-vida-landing",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "export": "next export",
+    "deploy": "next build && next export"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <div>
+      <Head>
+        <title>Casa-VidaOS</title>
+        <meta name="description" content="Casa-VidaOS landing page" />
+      </Head>
+      <main>
+        <h1>Welcome to Casa-VidaOS</h1>
+        <p>The operating system for a better living.</p>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project skeleton for Casa-VidaOS
- configure Next.js for GitHub Pages export
- add README with basic usage

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844b56b10c483329183387c30709b65